### PR TITLE
Using links instead of ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ cython_debug/
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 
 config.ini
+.idea

--- a/arxiv_update_bot/main.py
+++ b/arxiv_update_bot/main.py
@@ -134,7 +134,7 @@ def send_articles(
         for article in articles:
             bot.send_message(
                 chat_id,
-                text=f"<strong>Title</strong>: {article.title}\n<strong>Authors</strong>: {article.authors[0]['name']}\n<strong>Link</strong>: {article.id}",
+                text=f"<strong>Title</strong>: {article.title}\n<strong>Authors</strong>: {article.authors[0]['name']}\n<strong>Link</strong>: {article.link}",
             )
 
 


### PR DESCRIPTION
Fixes the issue about urls not being clickable in Telegram